### PR TITLE
ci: use containers instead of installing texlive-full in each run

### DIFF
--- a/.github/scripts/latex.sh
+++ b/.github/scripts/latex.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+set -e
+
+apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+  python3-pip \
+  python3-setuptools \
+  python3-wheel
+
+cd $(dirname $0)/../../docs
+
+pip3 install --user -r requirements.txt
+
+cd build/latex
+LATEXMKOPTS='-interaction=nonstopmode' make
+cp *.pdf ../html/

--- a/.github/scripts/sphinx.sh
+++ b/.github/scripts/sphinx.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+set -e
+
+cd $(dirname $0)/../../docs
+
+pip3 install --user -r requirements.txt
+
+make html latex

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,27 +10,27 @@ jobs:
   docs-generation:
     runs-on: ubuntu-latest
     steps:
+
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+
+      - uses: docker://btdi/sphinx:min
         with:
-          python-version: 3.9
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y texlive-full
-          python -m pip install -r docs/requirements.txt
-      - name: Generate documentation
-        run: |
-          cd docs
-          make html latexpdf
-          cp build/latex/*.pdf build/html/
-      - uses: actions/upload-artifact@v3
+          args: ./.github/scripts/sphinx.sh
+
+      - uses: docker://btdi/latex
         with:
-          name: gh-page
+          args: ./.github/scripts/latex.sh
+
+      - name: 'Upload artifact: Sphinx HTML and PDF'
+        uses: actions/upload-artifact@v3
+        with:
+          name: Documentation
           path: docs/build/html
+
       - name: Deploy to Github Pages
-        if: github.event_name == 'push'
+        if: github.ref == 'refs/heads/main'
         run: |
+          sudo chown -R $(whoami) docs
           cd docs/build/html
           touch .nojekyll
           git init


### PR DESCRIPTION
As done in Raviewer (see https://github.com/antmicro/raviewer/blob/main/.github/workflows/docs.yml), this PR uses containers instead of installing texlive-full in each run.